### PR TITLE
✨  Maintenance (support/exception classes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# integration-commons
-Library with common classes used for constructing MyParcel.com eCommerce Integrations
+# marketplace-commons
+Library with common classes used for constructing MyParcel.com marketplace integrations
 
 ## PHP 8
 The minimum PHP version is `8.2`. To update dependencies on a system without PHP 8 use:

--- a/composer.lock
+++ b/composer.lock
@@ -8,25 +8,25 @@
     "packages": [
         {
             "name": "brick/math",
-            "version": "0.11.0",
+            "version": "0.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "0ad82ce168c82ba30d1c01ec86116ab52f589478"
+                "reference": "f510c0a40911935b77b86859eb5223d58d660df1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/0ad82ce168c82ba30d1c01ec86116ab52f589478",
-                "reference": "0ad82ce168c82ba30d1c01ec86116ab52f589478",
+                "url": "https://api.github.com/repos/brick/math/zipball/f510c0a40911935b77b86859eb5223d58d660df1",
+                "reference": "f510c0a40911935b77b86859eb5223d58d660df1",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
-                "phpunit/phpunit": "^9.0",
-                "vimeo/psalm": "5.0.0"
+                "phpunit/phpunit": "^10.1",
+                "vimeo/psalm": "5.16.0"
             },
             "type": "library",
             "autoload": {
@@ -46,12 +46,17 @@
                 "arithmetic",
                 "bigdecimal",
                 "bignum",
+                "bignumber",
                 "brick",
-                "math"
+                "decimal",
+                "integer",
+                "math",
+                "mathematics",
+                "rational"
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.11.0"
+                "source": "https://github.com/brick/math/tree/0.12.1"
             },
             "funding": [
                 {
@@ -59,7 +64,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-15T23:15:59+00:00"
+            "time": "2023-11-29T23:19:16+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -2825,20 +2830,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.7.5",
+            "version": "4.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e"
+                "reference": "91039bc1faa45ba123c4328958e620d382ec7088"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e",
-                "reference": "5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/91039bc1faa45ba123c4328958e620d382ec7088",
+                "reference": "91039bc1faa45ba123c4328958e620d382ec7088",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11",
+                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12",
                 "ext-json": "*",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
@@ -2901,7 +2906,7 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.7.5"
+                "source": "https://github.com/ramsey/uuid/tree/4.7.6"
             },
             "funding": [
                 {
@@ -2913,20 +2918,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-08T05:53:05+00:00"
+            "time": "2024-04-27T21:32:50+00:00"
         },
         {
             "name": "symfony/clock",
-            "version": "v7.0.5",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "8b9d08887353d627d5f6c3bf3373b398b49051c2"
+                "reference": "2008671acb4a30b01c453de193cf9c80549ebda6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/8b9d08887353d627d5f6c3bf3373b398b49051c2",
-                "reference": "8b9d08887353d627d5f6c3bf3373b398b49051c2",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/2008671acb4a30b01c453de193cf9c80549ebda6",
+                "reference": "2008671acb4a30b01c453de193cf9c80549ebda6",
                 "shasum": ""
             },
             "require": {
@@ -2971,7 +2976,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v7.0.5"
+                "source": "https://github.com/symfony/clock/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -2987,20 +2992,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T12:46:12+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.0.6",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "fde915cd8e7eb99b3d531d3d5c09531429c3f9e5"
+                "reference": "c981e0e9380ce9f146416bde3150c79197ce9986"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/fde915cd8e7eb99b3d531d3d5c09531429c3f9e5",
-                "reference": "fde915cd8e7eb99b3d531d3d5c09531429c3f9e5",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c981e0e9380ce9f146416bde3150c79197ce9986",
+                "reference": "c981e0e9380ce9f146416bde3150c79197ce9986",
                 "shasum": ""
             },
             "require": {
@@ -3064,7 +3069,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.0.6"
+                "source": "https://github.com/symfony/console/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -3080,20 +3085,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-01T11:04:53+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v7.0.3",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "ec60a4edf94e63b0556b6a0888548bb400a3a3be"
+                "reference": "b08a4ad89e84b29cec285b7b1f781a7ae51cf4bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/ec60a4edf94e63b0556b6a0888548bb400a3a3be",
-                "reference": "ec60a4edf94e63b0556b6a0888548bb400a3a3be",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/b08a4ad89e84b29cec285b7b1f781a7ae51cf4bc",
+                "reference": "b08a4ad89e84b29cec285b7b1f781a7ae51cf4bc",
                 "shasum": ""
             },
             "require": {
@@ -3129,7 +3134,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v7.0.3"
+                "source": "https://github.com/symfony/css-selector/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -3145,7 +3150,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T15:02:46+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3216,16 +3221,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.0.6",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "46a4cc138f799886d4bd70477c55c699d3e9dfc8"
+                "reference": "cf97429887e40480c847bfeb6c3991e1e2c086ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/46a4cc138f799886d4bd70477c55c699d3e9dfc8",
-                "reference": "46a4cc138f799886d4bd70477c55c699d3e9dfc8",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/cf97429887e40480c847bfeb6c3991e1e2c086ab",
+                "reference": "cf97429887e40480c847bfeb6c3991e1e2c086ab",
                 "shasum": ""
             },
             "require": {
@@ -3271,7 +3276,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.0.6"
+                "source": "https://github.com/symfony/error-handler/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -3287,20 +3292,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-19T11:57:22+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.0.3",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "834c28d533dd0636f910909d01b9ff45cc094b5e"
+                "reference": "db2a7fab994d67d92356bb39c367db115d9d30f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/834c28d533dd0636f910909d01b9ff45cc094b5e",
-                "reference": "834c28d533dd0636f910909d01b9ff45cc094b5e",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/db2a7fab994d67d92356bb39c367db115d9d30f9",
+                "reference": "db2a7fab994d67d92356bb39c367db115d9d30f9",
                 "shasum": ""
             },
             "require": {
@@ -3351,7 +3356,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.0.3"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -3367,7 +3372,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T15:02:46+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -3447,16 +3452,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.0.0",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "6e5688d69f7cfc4ed4a511e96007e06c2d34ce56"
+                "reference": "4d58f0f4fe95a30d7b538d71197135483560b97c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/6e5688d69f7cfc4ed4a511e96007e06c2d34ce56",
-                "reference": "6e5688d69f7cfc4ed4a511e96007e06c2d34ce56",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/4d58f0f4fe95a30d7b538d71197135483560b97c",
+                "reference": "4d58f0f4fe95a30d7b538d71197135483560b97c",
                 "shasum": ""
             },
             "require": {
@@ -3491,7 +3496,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.0.0"
+                "source": "https://github.com/symfony/finder/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -3507,20 +3512,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-31T17:59:56+00:00"
+            "time": "2024-04-28T11:44:19+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.0.6",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "8789625dcf36e5fbf753014678a1e090f1bc759c"
+                "reference": "0194e064b8bdc29381462f790bab04e1cac8fdc8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/8789625dcf36e5fbf753014678a1e090f1bc759c",
-                "reference": "8789625dcf36e5fbf753014678a1e090f1bc759c",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/0194e064b8bdc29381462f790bab04e1cac8fdc8",
+                "reference": "0194e064b8bdc29381462f790bab04e1cac8fdc8",
                 "shasum": ""
             },
             "require": {
@@ -3568,7 +3573,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.0.6"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -3584,20 +3589,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-19T11:46:48+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.0.6",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "34c872391046d59af804af62d4573b829cfe4824"
+                "reference": "e07bb9bd86e7cd8ba2d3d9c618eec9d1bbe06d25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/34c872391046d59af804af62d4573b829cfe4824",
-                "reference": "34c872391046d59af804af62d4573b829cfe4824",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/e07bb9bd86e7cd8ba2d3d9c618eec9d1bbe06d25",
+                "reference": "e07bb9bd86e7cd8ba2d3d9c618eec9d1bbe06d25",
                 "shasum": ""
             },
             "require": {
@@ -3651,6 +3656,7 @@
                 "symfony/translation-contracts": "^2.5|^3",
                 "symfony/uid": "^6.4|^7.0",
                 "symfony/validator": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0",
                 "symfony/var-exporter": "^6.4|^7.0",
                 "twig/twig": "^3.0.4"
             },
@@ -3680,7 +3686,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.0.6"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -3696,20 +3702,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-03T06:12:25+00:00"
+            "time": "2024-04-29T12:20:25+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.0.6",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "eb0c3187c7ddfde12d8aa0e1fa5fb29e730a41e0"
+                "reference": "4ff41a7c7998a88cfdc31b5841ef64d9246fc56a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/eb0c3187c7ddfde12d8aa0e1fa5fb29e730a41e0",
-                "reference": "eb0c3187c7ddfde12d8aa0e1fa5fb29e730a41e0",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/4ff41a7c7998a88cfdc31b5841ef64d9246fc56a",
+                "reference": "4ff41a7c7998a88cfdc31b5841ef64d9246fc56a",
                 "shasum": ""
             },
             "require": {
@@ -3760,7 +3766,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.0.6"
+                "source": "https://github.com/symfony/mailer/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -3776,20 +3782,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-28T09:20:36+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.0.6",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "99362408c9abdf8c7cadcf0529b6fc8b16f5ace2"
+                "reference": "3adbf110c306546f6f00337f421d2edca0e8d3c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/99362408c9abdf8c7cadcf0529b6fc8b16f5ace2",
-                "reference": "99362408c9abdf8c7cadcf0529b6fc8b16f5ace2",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/3adbf110c306546f6f00337f421d2edca0e8d3c0",
+                "reference": "3adbf110c306546f6f00337f421d2edca0e8d3c0",
                 "shasum": ""
             },
             "require": {
@@ -3844,7 +3850,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.0.6"
+                "source": "https://github.com/symfony/mime/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -3860,7 +3866,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-21T19:37:36+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4575,16 +4581,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.0.4",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "0e7727191c3b71ebec6d529fa0e50a01ca5679e9"
+                "reference": "3839e56b94dd1dbd13235d27504e66baf23faba0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/0e7727191c3b71ebec6d529fa0e50a01ca5679e9",
-                "reference": "0e7727191c3b71ebec6d529fa0e50a01ca5679e9",
+                "url": "https://api.github.com/repos/symfony/process/zipball/3839e56b94dd1dbd13235d27504e66baf23faba0",
+                "reference": "3839e56b94dd1dbd13235d27504e66baf23faba0",
                 "shasum": ""
             },
             "require": {
@@ -4616,7 +4622,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.0.4"
+                "source": "https://github.com/symfony/process/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -4632,20 +4638,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-22T20:27:20+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v7.0.6",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "cded64e5bbf9f31786f1055fcc76718fdd77519c"
+                "reference": "9f82bf7766ccc9c22ab7aeb9bebb98351483fa5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/cded64e5bbf9f31786f1055fcc76718fdd77519c",
-                "reference": "cded64e5bbf9f31786f1055fcc76718fdd77519c",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/9f82bf7766ccc9c22ab7aeb9bebb98351483fa5b",
+                "reference": "9f82bf7766ccc9c22ab7aeb9bebb98351483fa5b",
                 "shasum": ""
             },
             "require": {
@@ -4697,7 +4703,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.0.6"
+                "source": "https://github.com/symfony/routing/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -4713,7 +4719,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-28T21:02:11+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4799,16 +4805,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.0.4",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "f5832521b998b0bec40bee688ad5de98d4cf111b"
+                "reference": "e405b5424dc2528e02e31ba26b83a79fd4eb8f63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f5832521b998b0bec40bee688ad5de98d4cf111b",
-                "reference": "f5832521b998b0bec40bee688ad5de98d4cf111b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/e405b5424dc2528e02e31ba26b83a79fd4eb8f63",
+                "reference": "e405b5424dc2528e02e31ba26b83a79fd4eb8f63",
                 "shasum": ""
             },
             "require": {
@@ -4865,7 +4871,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.0.4"
+                "source": "https://github.com/symfony/string/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -4881,20 +4887,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-01T13:17:36+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v7.0.4",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "5b75e872f7d135d7abb4613809fadc8d9f3d30a0"
+                "reference": "1515e03afaa93e6419aba5d5c9d209159317100b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/5b75e872f7d135d7abb4613809fadc8d9f3d30a0",
-                "reference": "5b75e872f7d135d7abb4613809fadc8d9f3d30a0",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/1515e03afaa93e6419aba5d5c9d209159317100b",
+                "reference": "1515e03afaa93e6419aba5d5c9d209159317100b",
                 "shasum": ""
             },
             "require": {
@@ -4959,7 +4965,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v7.0.4"
+                "source": "https://github.com/symfony/translation/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -4975,7 +4981,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-22T20:27:20+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -5057,16 +5063,16 @@
         },
         {
             "name": "symfony/uid",
-            "version": "v7.0.3",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "87cedaf3fabd7b733859d4d77aa4ca598259054b"
+                "reference": "4f3a5d181999e25918586c8369de09e7814e7be2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/87cedaf3fabd7b733859d4d77aa4ca598259054b",
-                "reference": "87cedaf3fabd7b733859d4d77aa4ca598259054b",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/4f3a5d181999e25918586c8369de09e7814e7be2",
+                "reference": "4f3a5d181999e25918586c8369de09e7814e7be2",
                 "shasum": ""
             },
             "require": {
@@ -5111,7 +5117,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v7.0.3"
+                "source": "https://github.com/symfony/uid/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -5127,20 +5133,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T15:02:46+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.0.6",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "66d13dc207d5dab6b4f4c2b5460efe1bea29dbfb"
+                "reference": "d1627b66fd87c8b4d90cabe5671c29d575690924"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/66d13dc207d5dab6b4f4c2b5460efe1bea29dbfb",
-                "reference": "66d13dc207d5dab6b4f4c2b5460efe1bea29dbfb",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/d1627b66fd87c8b4d90cabe5671c29d575690924",
+                "reference": "d1627b66fd87c8b4d90cabe5671c29d575690924",
                 "shasum": ""
             },
             "require": {
@@ -5194,7 +5200,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.0.6"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -5210,7 +5216,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-19T11:57:22+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -6344,12 +6350,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "74d263d0c5bb600a8c7254f031c81de7c6267e59"
+                "reference": "c9920ef42818bc65373cec1acc26bdee7a487e72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/74d263d0c5bb600a8c7254f031c81de7c6267e59",
-                "reference": "74d263d0c5bb600a8c7254f031c81de7c6267e59",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/c9920ef42818bc65373cec1acc26bdee7a487e72",
+                "reference": "c9920ef42818bc65373cec1acc26bdee7a487e72",
                 "shasum": ""
             },
             "conflict": {
@@ -6757,7 +6763,7 @@
                 "pagarme/pagarme-php": "<3",
                 "pagekit/pagekit": "<=1.0.18",
                 "paragonie/random_compat": "<2",
-                "passbolt/passbolt_api": "<2.11",
+                "passbolt/passbolt_api": "<4.6.2",
                 "paypal/adaptivepayments-sdk-php": "<=3.9.2",
                 "paypal/invoice-sdk-php": "<=3.9",
                 "paypal/merchant-sdk-php": "<3.12",
@@ -7127,7 +7133,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-26T00:14:37+00:00"
+            "time": "2024-04-26T17:04:41+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/src/Exceptions/AbstractRequestException.php
+++ b/src/Exceptions/AbstractRequestException.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Integration\Exceptions;
+
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+abstract class AbstractRequestException extends InvalidArgumentException
+{
+    /**
+     * @psalm-pure
+     */
+    public function __construct(
+        protected string $title,
+        string $detail,
+        int $code = 0,
+        Throwable $previous = null,
+    ) {
+        parent::__construct($detail, $code, $previous);
+    }
+
+    public function render(): Response
+    {
+        return response()->json([
+            'errors' => [
+                [
+                    'status' => (string) $this->code,
+                    'title'  => $this->title,
+                    'detail' => $this->message,
+                ],
+            ],
+        ], $this->code);
+    }
+}

--- a/src/Exceptions/RequestInputException.php
+++ b/src/Exceptions/RequestInputException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Integration\Exceptions;
+
+use Throwable;
+
+class RequestInputException extends AbstractRequestException
+{
+    public function __construct(
+        protected string $title,
+        string $detail,
+        int $code = 400,
+        Throwable $previous = null,
+    ) {
+        parent::__construct($title, $detail, $code, $previous);
+    }
+}

--- a/src/Exceptions/RequestUnauthorizedException.php
+++ b/src/Exceptions/RequestUnauthorizedException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Integration\Exceptions;
+
+use Throwable;
+
+class RequestUnauthorizedException extends AbstractRequestException
+{
+    public function __construct(
+        protected string $title,
+        string $detail,
+        int $code = 401,
+        Throwable $previous = null,
+    ) {
+        parent::__construct($title, $detail, $code, $previous);
+    }
+}

--- a/src/Http/Requests/FormRequest.php
+++ b/src/Http/Requests/FormRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Integration\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest as IlluminateFormRequest;
+use MyParcelCom\Integration\Exceptions\RequestInputException;
+use MyParcelCom\Integration\ShopId;
+use Ramsey\Uuid\Exception\InvalidUuidStringException;
+use Ramsey\Uuid\Uuid;
+
+class FormRequest extends IlluminateFormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    public function shopId(): ShopId
+    {
+        $shopId = $this->query('shop_id');
+
+        if (!$shopId) {
+            throw new RequestInputException('Bad request', 'No shop_id provided in the request query');
+        }
+
+        try {
+            $shopUuid = Uuid::fromString($shopId);
+        } catch (InvalidUuidStringException) {
+            throw new RequestInputException('Unprocessable entity', 'shop_id is not a valid UUID', 422);
+        }
+
+        return new ShopId($shopUuid);
+    }
+}

--- a/src/Http/Requests/OrdersCountRequest.php
+++ b/src/Http/Requests/OrdersCountRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Integration\Http\Requests;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Validator;
+
+class OrdersCountRequest extends FormRequest
+{
+    private const DATE_FORMAT = 'Y-m-d';
+
+    public function dateFrom(): Carbon
+    {
+        $from = $this->query('date_from');
+        if (!$from) {
+            return Carbon::now()->subDay();
+        }
+
+        $this->validateDateFormat($from);
+
+        return $this->toCarbon($from);
+    }
+
+    public function dateTo(): Carbon
+    {
+        $to = $this->query('date_to');
+        if (!$to) {
+            return Carbon::now();
+        }
+
+        $this->validateDateFormat($to);
+
+        return $this->toCarbon($to);
+    }
+
+    private function validateDateFormat(string $date): void
+    {
+        Validator::validate(
+            ['date' => $date],
+            ['date' => 'date_format:' . self::DATE_FORMAT],
+        );
+    }
+
+    private function toCarbon(string $date): Carbon
+    {
+        return Carbon::createFromFormat(self::DATE_FORMAT, $date)->startOfDay();
+    }
+}

--- a/src/Http/Requests/ShipmentRequest.php
+++ b/src/Http/Requests/ShipmentRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Integration\Http\Requests;
+
+use Carbon\Carbon;
+
+class ShipmentRequest extends FormRequest
+{
+    public function startDate(): Carbon
+    {
+        return Carbon::createFromFormat('Y-m-d H:i:s', $this->input('filter.start_date') . ' 00:00:00');
+    }
+
+    public function endDate(): Carbon
+    {
+        return Carbon::createFromFormat('Y-m-d H:i:s', $this->input('filter.end_date') . ' 23:59:59');
+    }
+
+    /**
+     * @return int|null
+     */
+    public function pageNumber(): ?int
+    {
+        return $this->input('page.number') ? (int) $this->input('page.number') : null;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function pageSize(): ?int
+    {
+        return $this->input('page.size') ? (int) $this->input('page.size') : null;
+    }
+}

--- a/src/Http/Requests/ShipmentStatusCallbackRequest.php
+++ b/src/Http/Requests/ShipmentStatusCallbackRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Integration\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Arr;
+use MyParcelCom\Integration\Exceptions\RequestInputException;
+use MyParcelCom\Integration\ShopId;
+use Ramsey\Uuid\Exception\InvalidUuidStringException;
+use Ramsey\Uuid\Uuid;
+
+class ShipmentStatusCallbackRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+
+    public function getShipmentData(): array
+    {
+        $included = $this->get('included');
+
+        return collect($included)->first(fn ($include) => $include['type'] === 'shipments');
+    }
+
+    public function getStatusData(): array
+    {
+        $included = $this->get('included');
+
+        return collect($included)->first(fn ($include) => $include['type'] === 'statuses');
+    }
+
+    public function shopId(): ShopId
+    {
+        $shopId = Arr::get($this->getShipmentData(), 'relationships.shop.data.id');
+
+        if (!$shopId) {
+            throw new RequestInputException('Bad request', 'No shop_id provided in the request body');
+        }
+
+        try {
+            $shopUuid = Uuid::fromString($shopId);
+        } catch (InvalidUuidStringException $exception) {
+            throw new RequestInputException('Unprocessable entity', 'shop_id is not a valid UUID', 422);
+        }
+
+        return new ShopId($shopUuid);
+    }
+}

--- a/src/Http/Requests/ShopSetupRequest.php
+++ b/src/Http/Requests/ShopSetupRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Integration\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ShopSetupRequest extends FormRequest
+{
+    public function authorize(): true
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'data.settings'     => 'array',
+            'data.redirect_url' => 'url',
+        ];
+    }
+
+    public function redirectUrl(): ?string
+    {
+        return $this->input('data.redirect_url');
+    }
+}

--- a/src/Http/Responses/ShopSetupResponse.php
+++ b/src/Http/Responses/ShopSetupResponse.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Integration\Http\Responses;
+
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+class ShopSetupResponse implements Responsable
+{
+    public function __construct(
+        private readonly ?string $authorizationUrl = null,
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function toResponse($request): SymfonyResponse
+    {
+        if (!$this->authorizationUrl) {
+            return new Response('', SymfonyResponse::HTTP_NO_CONTENT);
+        }
+
+        return new JsonResponse([
+            'data' => [
+                'authorization_url' => $this->authorizationUrl,
+            ]
+        ]);
+    }
+}

--- a/src/Http/Responses/ShopTearDownResponse.php
+++ b/src/Http/Responses/ShopTearDownResponse.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Integration\Http\Responses;
+
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+class ShopTearDownResponse implements Responsable
+{
+    /**
+     * @inheritDoc
+     */
+    public function toResponse($request): SymfonyResponse
+    {
+        return new Response('', SymfonyResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Order/Items/Feature.php
+++ b/src/Order/Items/Feature.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\Integration\Order\Items;
 
-use JetBrains\PhpStorm\ArrayShape;
-
 class Feature
 {
     public function __construct(
@@ -15,7 +13,13 @@ class Feature
     ) {
     }
 
-    #[ArrayShape(['key' => 'string', 'value' => 'string|int|float|bool', 'annotation' => 'string|null'])]
+    /**
+     * @return array{
+     *     key: string,
+     *     value: string|int|float|bool,
+     *     annotation: string|null
+     * }
+     */
     public function toArray(): array
     {
         return array_filter([

--- a/src/PhysicalProperties.php
+++ b/src/PhysicalProperties.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\Integration;
 
-use JetBrains\PhpStorm\ArrayShape;
-
 class PhysicalProperties
 {
     public function __construct(
@@ -17,13 +15,15 @@ class PhysicalProperties
     ) {
     }
 
-    #[ArrayShape([
-        'weight' => 'int',
-        'height' => 'int|null',
-        'width'  => 'int|null',
-        'length' => 'int|null',
-        'volume' => 'float|null',
-    ])]
+    /**
+     * @return array{
+     *     weight: int,
+     *     height: int|null,
+     *     width: int|null,
+     *     length: int|null,
+     *     volume: float|null
+     * }
+     */
     public function toArray(): array
     {
         return array_filter([

--- a/src/Price.php
+++ b/src/Price.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\Integration;
 
-use JetBrains\PhpStorm\ArrayShape;
-
 class Price
 {
     public function __construct(
@@ -14,7 +12,9 @@ class Price
     ) {
     }
 
-    #[ArrayShape(['amount' => 'int', 'currency' => 'string'])]
+    /**
+     * @return array{amount: int, currency: string}
+     */
     public function toArray(): array
     {
         return [

--- a/src/ShopId.php
+++ b/src/ShopId.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace MyParcelCom\Integration;
 
-use JetBrains\PhpStorm\Immutable;
 use Ramsey\Uuid\UuidInterface;
 
-#[Immutable]
+/**
+ * @psalm-immutable
+ */
 class ShopId
 {
     public function __construct(

--- a/src/Support/ShopIdCaster.php
+++ b/src/Support/ShopIdCaster.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\Integration\Support;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+use MyParcelCom\Integration\ShopId;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * @implements CastsAttributes<ShopId,ShopId>
+ */
+class ShopIdCaster implements CastsAttributes
+{
+    public function get(Model $model, string $key, mixed $value, array $attributes): ShopId
+    {
+        return new ShopId(Uuid::fromString($value));
+    }
+
+    public function set(Model $model, string $key, mixed $value, array $attributes): string
+    {
+        return $value->toString();
+    }
+}

--- a/src/Weight.php
+++ b/src/Weight.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\Integration;
 
-use JetBrains\PhpStorm\ArrayShape;
-
 class Weight
 {
     public function __construct(
@@ -14,7 +12,9 @@ class Weight
     ) {
     }
 
-    #[ArrayShape(['amount' => 'int', 'unit' => 'string'])]
+    /**
+     * @return array{amount: int, unit: string}
+     */
     public function toArray(): array
     {
         return [

--- a/tests/Http/Requests/FormRequestTest.php
+++ b/tests/Http/Requests/FormRequestTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Http\Requests;
+
+use MyParcelCom\Integration\Http\Requests\FormRequest;
+use PHPUnit\Framework\TestCase;
+
+class FormRequestTest extends TestCase
+{
+    public function testShopId(): void
+    {
+        $request = new FormRequest();
+        $request->initialize(['shop_id' => '123e4567-e89b-12d3-a456-426614174000']);
+
+        $this->assertEquals('123e4567-e89b-12d3-a456-426614174000', $request->shopId()->toString());
+    }
+
+    public function testShopIdThrowsExceptionWhenNoShopIdProvided(): void
+    {
+        $request = new FormRequest();
+
+        $this->expectExceptionMessage('No shop_id provided in the request query');
+        $request->shopId();
+    }
+
+    public function testShopIdThrowsExceptionWhenShopIdIsNotValidUuid(): void
+    {
+        $request = new FormRequest();
+        $request->initialize(['shop_id' => 'invalid-uuid']);
+
+        $this->expectExceptionMessage('shop_id is not a valid UUID');
+        $request->shopId();
+    }
+}


### PR DESCRIPTION
## What's new
The following entities have been moved to the commons package:
- app/Exceptions
- app/Support/ShopIdCaster.php
- app/Http/Requests/FormRequest

The following new classes were added to commons package and have to be utilized on each integration specifically:
- ShopSetupRequest
- ShopSetupResponse
- OrdersCountRequest
- ShipmentRequest
- ShipmentStatusCallbackRequest

The following were removed completely:
- app/Authentication
- auth routes from routes/api.php
- all feature and unit tests
- OrderRequest

In addition, I deprecated the JetBrains attributes in favor of psalm. These jetbrains attributes are not as flexible.