### PR TITLE
📣  Make entity readonly properties public

### DIFF
--- a/src/Address.php
+++ b/src/Address.php
@@ -7,19 +7,19 @@ namespace MyParcelCom\Integration;
 class Address
 {
     public function __construct(
-        private readonly string $street1,
-        private readonly string $city,
-        private readonly string $countryCode,
-        private readonly string $firstName,
-        private readonly string $lastName,
-        private readonly ?string $street2 = null,
-        private readonly ?int $streetNumber = null,
-        private readonly ?string $streetNumberSuffix = null,
-        private readonly ?string $postalCode = null,
-        private readonly ?string $stateCode = null,
-        private readonly ?string $company = null,
-        private readonly ?string $email = null,
-        private readonly ?string $phoneNumber = null,
+        public readonly string $street1,
+        public readonly string $city,
+        public readonly string $countryCode,
+        public readonly string $firstName,
+        public readonly string $lastName,
+        public readonly ?string $street2 = null,
+        public readonly ?int $streetNumber = null,
+        public readonly ?string $streetNumberSuffix = null,
+        public readonly ?string $postalCode = null,
+        public readonly ?string $stateCode = null,
+        public readonly ?string $company = null,
+        public readonly ?string $email = null,
+        public readonly ?string $phoneNumber = null,
     ) {
     }
 

--- a/src/Order/Items/Feature.php
+++ b/src/Order/Items/Feature.php
@@ -7,9 +7,9 @@ namespace MyParcelCom\Integration\Order\Items;
 class Feature
 {
     public function __construct(
-        private readonly string $key,
-        private readonly string|int|float|bool $value,
-        private readonly ?Annotation $annotation = null,
+        public readonly string $key,
+        public readonly string|int|float|bool $value,
+        public readonly ?Annotation $annotation = null,
     ) {
     }
 

--- a/src/Order/Items/Item.php
+++ b/src/Order/Items/Item.php
@@ -10,15 +10,15 @@ use MyParcelCom\Integration\Weight;
 class Item
 {
     public function __construct(
-        private readonly string $id,
-        private readonly string $name,
-        private readonly string $description,
-        private readonly int $quantity,
-        private readonly Price $itemPrice,
-        private readonly ?string $sku = null,
-        private readonly ?string $imageUrl = null,
-        private readonly ?Weight $itemWeight = null,
-        private readonly ?FeatureCollection $features = null,
+        public readonly string $id,
+        public readonly string $name,
+        public readonly string $description,
+        public readonly int $quantity,
+        public readonly Price $itemPrice,
+        public readonly ?string $sku = null,
+        public readonly ?string $imageUrl = null,
+        public readonly ?Weight $itemWeight = null,
+        public readonly ?FeatureCollection $features = null,
     ) {
     }
 

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -13,12 +13,12 @@ use MyParcelCom\Integration\ShopId;
 class Order implements ProvidesJsonAPI
 {
     public function __construct(
-        private readonly ShopId $shopId,
-        private readonly string $id,
-        private readonly DateTimeInterface $createdAt,
-        private readonly Address $recipientAddress,
-        private readonly ItemCollection $items,
-        private readonly ?string $outboundShipmentIdentifier = null,
+        public readonly ShopId $shopId,
+        public readonly string $id,
+        public readonly DateTimeInterface $createdAt,
+        public readonly Address $recipientAddress,
+        public readonly ItemCollection $items,
+        public readonly ?string $outboundShipmentIdentifier = null,
     ) {
     }
 

--- a/src/PhysicalProperties.php
+++ b/src/PhysicalProperties.php
@@ -7,11 +7,11 @@ namespace MyParcelCom\Integration;
 class PhysicalProperties
 {
     public function __construct(
-        private readonly ?int $weight = null,
-        private readonly ?int $height = null,
-        private readonly ?int $width = null,
-        private readonly ?int $length = null,
-        private readonly ?float $volume = null,
+        public readonly ?int $weight = null,
+        public readonly ?int $height = null,
+        public readonly ?int $width = null,
+        public readonly ?int $length = null,
+        public readonly ?float $volume = null,
     ) {
     }
 

--- a/src/Price.php
+++ b/src/Price.php
@@ -7,8 +7,8 @@ namespace MyParcelCom\Integration;
 class Price
 {
     public function __construct(
-        private readonly int $amount,
-        private readonly string $currency,
+        public readonly int $amount,
+        public readonly string $currency,
     ) {
     }
 

--- a/src/Shipment/Customs/Customs.php
+++ b/src/Shipment/Customs/Customs.php
@@ -9,13 +9,13 @@ use MyParcelCom\Integration\Price;
 class Customs
 {
     public function __construct(
-        private readonly ?ContentType $contentType = null,
-        private readonly ?string $invoiceNumber = null,
-        private readonly ?NonDelivery $nonDelivery = null,
-        private readonly ?Incoterm $incoterm = null,
-        private readonly ?Price $shippingValue = null,
-        private readonly ?string $licenseNumber = null,
-        private readonly ?string $certificateNumber = null,
+        public readonly ?ContentType $contentType = null,
+        public readonly ?string $invoiceNumber = null,
+        public readonly ?NonDelivery $nonDelivery = null,
+        public readonly ?Incoterm $incoterm = null,
+        public readonly ?Price $shippingValue = null,
+        public readonly ?string $licenseNumber = null,
+        public readonly ?string $certificateNumber = null,
     ) {
     }
 

--- a/src/Shipment/Items/Item.php
+++ b/src/Shipment/Items/Item.php
@@ -9,15 +9,15 @@ use MyParcelCom\Integration\Price;
 class Item
 {
     public function __construct(
-        private readonly ?string $description = null,
-        private readonly ?int $quantity = null,
-        private readonly ?string $sku = null,
-        private readonly ?string $imageUrl = null,
-        private readonly ?Price $itemValue = null,
-        private readonly ?string $hsCode = null,
-        private readonly ?int $itemWeight = null,
-        private readonly ?string $originCountryCode = null,
-        private readonly bool $isPreferentialOrigin = false,
+        public readonly ?string $description = null,
+        public readonly ?int $quantity = null,
+        public readonly ?string $sku = null,
+        public readonly ?string $imageUrl = null,
+        public readonly ?Price $itemValue = null,
+        public readonly ?string $hsCode = null,
+        public readonly ?int $itemWeight = null,
+        public readonly ?string $originCountryCode = null,
+        public readonly bool $isPreferentialOrigin = false,
     ) {
     }
 

--- a/src/Shipment/Shipment.php
+++ b/src/Shipment/Shipment.php
@@ -19,22 +19,22 @@ use MyParcelCom\Integration\ShopId;
 class Shipment implements ProvidesJsonAPI
 {
     public function __construct(
-        private readonly ShopId $shopId,
-        private readonly Address $recipientAddress,
-        private readonly string $description,
-        private readonly string $customerReference,
-        private readonly string $channel,
-        private readonly Price $totalValue,
-        private readonly Price $price,
-        private readonly PhysicalProperties $physicalProperties,
-        private readonly ItemCollection $items,
-        private readonly ?DateTimeInterface $createdAt = null,
-        private readonly ?Address $senderAddress = null,
-        private readonly ?Address $returnAddress = null,
-        private readonly ?TaxIdentificationNumberCollection $senderTaxIdentificationNumbers = null,
-        private readonly ?TaxIdentificationNumberCollection $recipientTaxIdentificationNumbers = null,
-        private readonly ?Customs $customs = null,
-        private readonly array $tags = [],
+        public readonly ShopId $shopId,
+        public readonly Address $recipientAddress,
+        public readonly string $description,
+        public readonly string $customerReference,
+        public readonly string $channel,
+        public readonly Price $totalValue,
+        public readonly Price $price,
+        public readonly PhysicalProperties $physicalProperties,
+        public readonly ItemCollection $items,
+        public readonly ?DateTimeInterface $createdAt = null,
+        public readonly ?Address $senderAddress = null,
+        public readonly ?Address $returnAddress = null,
+        public readonly ?TaxIdentificationNumberCollection $senderTaxIdentificationNumbers = null,
+        public readonly ?TaxIdentificationNumberCollection $recipientTaxIdentificationNumbers = null,
+        public readonly ?Customs $customs = null,
+        public readonly array $tags = [],
     ) {
         if (empty($this->channel)) {
             throw new InvalidChannelException('Shipment channel cannot be empty');

--- a/src/Shipment/TaxIdentificationNumbers/TaxIdentificationNumber.php
+++ b/src/Shipment/TaxIdentificationNumbers/TaxIdentificationNumber.php
@@ -7,10 +7,10 @@ namespace MyParcelCom\Integration\Shipment\TaxIdentificationNumbers;
 class TaxIdentificationNumber
 {
     public function __construct(
-        private readonly string $countryCode,
-        private readonly TaxNumberType $type,
-        private readonly string $number,
-        private readonly ?string $description = null,
+        public readonly string $countryCode,
+        public readonly TaxNumberType $type,
+        public readonly string $number,
+        public readonly ?string $description = null,
     ) {
     }
 

--- a/src/ShopId.php
+++ b/src/ShopId.php
@@ -12,7 +12,7 @@ use Ramsey\Uuid\UuidInterface;
 class ShopId
 {
     public function __construct(
-        private readonly UuidInterface $uuid,
+        public readonly UuidInterface $uuid,
     ) {
     }
 

--- a/src/Weight.php
+++ b/src/Weight.php
@@ -7,8 +7,8 @@ namespace MyParcelCom\Integration;
 class Weight
 {
     public function __construct(
-        private readonly int $amount,
-        private readonly WeightUnit $unit,
+        public readonly int $amount,
+        public readonly WeightUnit $unit,
     ) {
     }
 


### PR DESCRIPTION
# What's Changed
It is handy to have these properties public because now since they are `readonly` they can't be modified. Meanwhile, if you want to run a filter for example on order item collection you can't really do much because the properties are private and not accessible. 