### PR TITLE
🐞  Redirect URL is actually not always required

### DIFF
--- a/src/Shop/Http/Requests/ShopSetupRequest.php
+++ b/src/Shop/Http/Requests/ShopSetupRequest.php
@@ -12,7 +12,7 @@ class ShopSetupRequest extends FormRequest
     {
         return [
             'data.settings'         => 'array',
-            'data.redirect_url'     => 'required|url',
+            'data.redirect_url'     => 'url',
             // Optional, but if exists, it must be an array with 2 elements.
             // This makes sure that an empty array wouldn't` pass the validation.
             'data.mp_client'        => 'array|min:2|max:2',

--- a/tests/Shop/Http/Requests/ShopSetupRequestTest.php
+++ b/tests/Shop/Http/Requests/ShopSetupRequestTest.php
@@ -24,6 +24,8 @@ class ShopSetupRequestTest extends TestCase
         $faker = Factory::create();
 
         return [
+            [[]],
+            [['data' => []]],
             [
                 [
                     'data' => [
@@ -42,6 +44,16 @@ class ShopSetupRequestTest extends TestCase
                             'foo' => 'bar',
                         ],
                         'redirect_url' => $faker->url(),
+                    ],
+                ],
+            ],
+            [
+                [
+                    'data' => [
+                        'settings'     => [
+                            'foo' => 'bar',
+                        ],
+                        'mp_client'    => ['id' => $faker->uuid(), 'secret' => $faker->password()],
                     ],
                 ],
             ],
@@ -86,19 +98,6 @@ class ShopSetupRequestTest extends TestCase
                         ],
                         'redirect_url' => $faker->url(),
                         'mp_client'    => [],
-                    ],
-                ],
-            ],
-            // Missing redirect_url
-            [[]],
-            [['data' => []]],
-            [
-                [
-                    'data' => [
-                        'settings'     => [
-                            'foo' => 'bar',
-                        ],
-                        'mp_client'    => ['id' => $faker->uuid(), 'secret' => $faker->password()],
                     ],
                 ],
             ],


### PR DESCRIPTION
This pull request includes changes to the `ShopSetupRequest` validation rules and updates to the corresponding test cases in `ShopSetupRequestTest`. The most important changes include making the `data.redirect_url` field optional and updating the test cases to reflect this change.

Changes to validation rules:

* [`src/Shop/Http/Requests/ShopSetupRequest.php`](diffhunk://#diff-4205796867c6da4f08e94bc7a4b9d4d1b7bbe9d783074730855c376b655654dfL15-R15): The `data.redirect_url` field is no longer required, making it optional.

Updates to test cases:

* [`tests/Shop/Http/Requests/ShopSetupRequestTest.php`](diffhunk://#diff-ee08e005ee2b7b6561f06042a4b1c6b77a0562d5147beaf959ef8209a9f0f901R27-R28): Added new test cases to the `success_data` method to cover scenarios with and without the `data.redirect_url` field. [[1]](diffhunk://#diff-ee08e005ee2b7b6561f06042a4b1c6b77a0562d5147beaf959ef8209a9f0f901R27-R28) [[2]](diffhunk://#diff-ee08e005ee2b7b6561f06042a4b1c6b77a0562d5147beaf959ef8209a9f0f901R50-R59)
* [`tests/Shop/Http/Requests/ShopSetupRequestTest.php`](diffhunk://#diff-ee08e005ee2b7b6561f06042a4b1c6b77a0562d5147beaf959ef8209a9f0f901L92-L104): Removed outdated test cases from the `failure_data` method that were based on the `data.redirect_url` field being required.